### PR TITLE
Authors added.

### DIFF
--- a/Rules
+++ b/Rules
@@ -17,17 +17,29 @@ require 'set'
 
 preprocess do
   tags = Set.new
+  authors = Set.new
+
   items.each do |item|
     tags.merge(item[:tags] || [])
+    authors.merge(item[:authors] || [])
   end
 
   tags.each do |tag|
     items << Nanoc::Item.new("", { tag: tag }, "/nulog/#{tag}/")
   end
+
+  authors.each do |author|
+    items << Nanoc::Item.new("", { author: author }, "/nulog/#{author}/")
+  end
 end
 
-compile '/nulog/business|programming|innovation|society|technology|web/' do
+compile '/nulog/(business|programming|innovation|society|technology|web)/' do
   layout 'tag'
+  layout 'default'
+end
+
+compile '/nulog/(zaiste|albanlv|yaroq|adrien|tukan|tomkuk)/' do
+  layout 'author'
   layout 'default'
 end
 

--- a/content/blog/2012-03_can_we_hack_the_company_model.md
+++ b/content/blog/2012-03_can_we_hack_the_company_model.md
@@ -2,11 +2,13 @@
 kind: article
 created_at: 2012-03-02
 title: Can we hack the company model ?
+authors:
+ - company
 ---
 
-We would like to introduce you to a new approach on how to work together and make a living, as an alternative to traditional companies. It's an early draft, but we decided to publish it anyway in order to get feedback. 
+We would like to introduce you to a new approach on how to work together and make a living, as an alternative to traditional companies. It's an early draft, but we decided to publish it anyway in order to get feedback.
 
-From the beginning we didn't want to create a traditional company, being rather unsatisfied with existing models. We wanted to change that, to innovate it that field with a quite simple goal in mind: *how to make people happy at work?* as we profoundly believe that happy people are far more creative and productive, and such configuration makes *work* a very different concept. 
+From the beginning we didn't want to create a traditional company, being rather unsatisfied with existing models. We wanted to change that, to innovate it that field with a quite simple goal in mind: *how to make people happy at work?* as we profoundly believe that happy people are far more creative and productive, and such configuration makes *work* a very different concept.
 
 Nukomeet is about programmers that are passionate about their craft. Our approach can be summarized in six core principles:
 
@@ -24,28 +26,15 @@ The profit is shared, kept or invested according to the will of the people in th
 
 **3. We are equal.**
 
-We think hierarchies belong to another age. What is more, we believe that the workers, those who create the value, should take decisions. Because it is fair, and because it is natural - they know what is at stake as well or even better than managers. 
+We think hierarchies belong to another age. What is more, we believe that the workers, those who create the value, should take decisions. Because it is fair, and because it is natural - they know what is at stake as well or even better than managers.
 
 **4. We trust each other.**
 
-Trust is a crucial element to establish a great company culture. For us, a company moves forward only if everyone cares about. We don't hire people who don't care about the company, who believe it is *their* company. 
+Trust is a crucial element to establish a great company culture. For us, a company moves forward only if everyone cares about. We don't hire people who don't care about the company, who believe it is *their* company.
 Therefore, we refuse to do micro-management. People work when they want, where they want, as they want. We assess only results.
 
 **5. We innovate.**
 
-The mission for Nukomeet is to become a innovation agency where people can start and grow their projects, using company resources if needed. We want to create an adapted environment for innovation. 
+The mission for Nukomeet is to become a innovation agency where people can start and grow their projects, using company resources if needed. We want to create an adapted environment for innovation.
 
 That's is our way. Please tell us what you think about it, what's wrong and what's good in it.
-
--- [@albanlv](http://twitter.com/albanlv) and [@zaiste](http://twitter.com/zaiste)
-
-- - -
-
-Nukomeet is a company ran by self-managed developers using cutting-edge technologies to build top-notch applications - for clients or for fun.
-
-We would be delighted to have your feedback on this post, please discuss it on Hacker News. 
-
-Feel free to ask us any questions on [Twitter](https://twitter.com/#!/nukomeet) or using [an email](mailto:bonjour@nukomeet.com)
-
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="nukomeet" data-size="large">Tweet</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/content/blog/2012-03_how_we_use_nanoc.md
+++ b/content/blog/2012-03_how_we_use_nanoc.md
@@ -1,29 +1,27 @@
 ---
-created_at: 2012-03-14 
+created_at: 2012-03-14
 kind: article
 publish: true
 title: "How we use Nanoc"
+authors:
+ - zaiste
 ---
-
-
-## Static Site Generator
 
 [Nanoc](http://nanoc.stoneship.org/) is a static site generator, and it is cool, mainly for three reasons:
 
-1. **speed:** it makes your website pretty fast as it's only HTML without any dynamic content 
+1. **speed:** it makes your website pretty fast as it's only HTML without any dynamic content
 1. **freedom:** you only need a HTTP server to host your website, no bells and whistles. It's a perfect, cross-platform solution. You can also use several markup languages, and even mix them together. We use HAML and Markdown.
 1. **simplicity:** no database connection and configuration, no graphical admin panel, only stuff that matters.
 
-
 ## Workflow
 
-Our workflow is pretty standard. We host our website code on GitHub, each contributor has its fork. Changes are being integrated using pull requests. 
+Our workflow is pretty standard. We host our website code on GitHub, each contributor has its fork. Changes are being integrated using pull requests.
 
-As of version 3.2, nanoc provides a simple DSL to create custom commands (based on [Cri library](http://rubydoc.info/gems/cri/2.0.0/file/README.md)). We used that functionality to automate blog posts creation. 
+As of version 3.2, nanoc provides a simple DSL to create custom commands (based on [Cri library](http://rubydoc.info/gems/cri/2.0.0/file/README.md)). We used that functionality to automate blog posts creation.
 
 <script src="https://gist.github.com/2032721.js?file=post.rb"></script>
 
-As you can see, we prefer to have a flat website structure. All posts are inside a blog directory. In addition to that we only use year and month to differentiate them.  
+As you can see, we prefer to have a flat website structure. All posts are inside a blog directory. In addition to that we only use year and month to differentiate them.
 
 To create a new post, you simply do:
 
@@ -37,12 +35,10 @@ you compile the website
 
     nanoc compile
 
-you check it locally at localhost:3000 
+you check it locally at localhost:3000
 
     nanoc view
 
 and finally you can push it to the server
 
     nanoc deploy --target public
-
--- Z!

--- a/content/blog/2012-04_pixel_developer_or_ruby_artist.md
+++ b/content/blog/2012-04_pixel_developer_or_ruby_artist.md
@@ -5,6 +5,8 @@ publish: true
 title: "Pixel developer or Ruby artist ?"
 tags:
 - team
+authors:
+- albanlv
 ---
 
 This is the story of **Łukasz** - better known in the internet society by his pseudonym **ofca**.

--- a/content/blog/2013-01_bitcoin.md
+++ b/content/blog/2013-01_bitcoin.md
@@ -6,6 +6,7 @@ publish: true
 tags:
 - society
 - innovation
+authors:
 ---
 
 Considering the recent surge of online services, like

--- a/content/css/override.css
+++ b/content/css/override.css
@@ -93,18 +93,44 @@ h4 {
 
 .entry-body h1.title {
     margin-top: 0;
-    margin-bottom: 0;
+    margin-bottom: 24px;
+    font-size: 18px;
+    border-bottom: 1px solid #EFEFEF;
+    padding-bottom: 6px;
 }
 
 article.entry:first-child {
-  padding: 0 0 24px;
+  padding: 0;
 }
 
 article.entry {
-  padding: 24px 0 24px;
+  padding: 24px 0 0;
   border-bottom: none;
 }
 
 .page-header h2 {
   text-align: center;
+}
+
+.entry-meta a {
+  font-style: normal;
+}
+
+h2.about {
+  border-top: 1px solid #CFCFCF;
+  line-height: 36px;
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.slogan {
+  font-size: 22px;
+}
+
+.empty-meta ul {
+  margin-bottom: 12px;
+}
+
+.entry-meta li {
+  margin-bottom: 12px;
 }

--- a/layouts/author.slim
+++ b/layouts/author.slim
@@ -1,0 +1,18 @@
+header.page-header
+  h2.page-subdescription
+    ' This is
+    strong Nulog,
+    '  a blog by Nukomeet about technology, society, business, Internet and geek stuff.
+
+section#main
+  - items_by_author(@item[:author]).each do |post|
+    article.entry.clearfix
+      .entry-body
+        a href="#{post.path}"
+          h1.title = post[:title]
+      .entry-meta
+        ul
+          li
+            a href="#" = post[:created_at].strftime("%b %d")
+
+== render 'sidebar'

--- a/layouts/authors/adrien.slim
+++ b/layouts/authors/adrien.slim
@@ -1,0 +1,10 @@
+h2.about About Adrien
+
+markdown:
+  Adrien is a partner at Nukomeet.
+
+  Read [all of Adrien's posts][1], [follow him on Twitter][2] and check his [personal website][3].
+
+  [1]: http://nukomeet.com/nulog/adrien/
+  [2]: http://twitter/adrien
+  [3]: http://

--- a/layouts/authors/albanlv.slim
+++ b/layouts/authors/albanlv.slim
@@ -1,0 +1,10 @@
+h2.about About Alban
+
+markdown:
+  Alban is Nukomeet cofounder.
+
+  Read [all of Alban's posts][1], [follow him on Twitter][2] and check his [personal website][3].
+
+  [1]: http://nukomeet.com/nulog/albanlv/
+  [2]: http://twitter/albanlv
+  [3]: http://

--- a/layouts/authors/company.slim
+++ b/layouts/authors/company.slim
@@ -1,0 +1,7 @@
+markdown:
+  ### About
+
+  Nukomeet is a company ran by self-managed programmers using cutting-edge technologies to build top-notch applications - for clients or for fun.
+
+  Feel free to ask us any questions on [Twitter](https://twitter.com/#!/nukomeet) or using [an email](mailto:bonjour@nukomeet.com)
+

--- a/layouts/authors/tomkuk.slim
+++ b/layouts/authors/tomkuk.slim
@@ -1,0 +1,10 @@
+h2.about About Tomek
+
+markdown:
+  Tomek is a partner at Nukomeet.
+
+  Read [all of Tomek's posts][1], [follow him on Twitter][2] and check his [personal website][3].
+
+  [1]: http://nukomeet.com/nulog/tomkuk/
+  [2]: http://twitter/tomkuk
+  [3]: http://

--- a/layouts/authors/tukan.slim
+++ b/layouts/authors/tukan.slim
@@ -1,0 +1,10 @@
+h2.about About Bartłomiej
+
+markdown:
+  Bartłomiej is a partner at Nukomeet.
+
+  Read [all of Bartłomiej's posts][1], [follow him on Twitter][2] and check his [personal website][3].
+
+  [1]: http://nukomeet.com/nulog/tukan/
+  [2]: http://twitter/tukan
+  [3]: http://

--- a/layouts/authors/yaroq.slim
+++ b/layouts/authors/yaroq.slim
@@ -1,0 +1,10 @@
+h2.about About Julien
+
+markdown:
+  Julien is a partner at Nukomeet.
+
+  Read [all of Julien's posts][1], [follow him on Twitter][2] and check his [personal website][3].
+
+  [1]: http://nukomeet.com/nulog/yaroq/
+  [2]: http://twitter/yaroq
+  [3]: http://

--- a/layouts/authors/zaiste.slim
+++ b/layouts/authors/zaiste.slim
@@ -1,0 +1,10 @@
+h2.about About Zaiste
+
+markdown:
+  Zaiste co-founded Nukomeet in 2012. Programming relaxes him. He adores being wrong.
+
+  Read [all of Zaiste's posts][1], [follow him on Twitter][2] and check his [personal website][3].
+
+  [1]: /nulog/zaiste/
+  [2]: http://twitter.com/zaiste
+  [3]: http://zaiste.net

--- a/layouts/post.slim
+++ b/layouts/post.slim
@@ -3,16 +3,17 @@ section#main
     .entry-body
       a href="#"
         h1.title = @item[:title]
+
       == yield
+
+      hr/
+
+      == render "authors/#{(@item[:authors] || ['company']).first}"
+
     .entry-meta
       ul
         li
-          a href="single-post.html"
-            span.post-format Permalink
-        li
-          span.title Posted:
-          a href="#" = @item[:created_at]
-        hr
+          a href="#" = @item[:created_at].strftime("%b %d")
         li
           a.twitter-share-button data-count="none" data-size="large" data-via="nukomeet" href="https://twitter.com/share" I share
           javascript:

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -27,3 +27,7 @@ def combined(assets, type='css')
 
   content.join("\n")
 end
+
+def items_by_author(author)
+  @items.select { |i| (i[:authors] || []).include?(author) }
+end


### PR DESCRIPTION
Blog post can be authored. A short description is automatically
included if post meta section contains `authors` entry, e.g.

```
authors:
- zaiste
```

Additionally, posts can be filtered by author, e.g. `/nulog/zaiste`
will show only Zaiste's blog posts.
