### PR TITLE
[WIP] Upgrade to nanoc 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'thin'
 
 gem 'builder'
 
-gem 'nanoc'
+gem 'nanoc', github: 'nanoc/nanoc'
 gem 'guard-nanoc'
 gem 'less'
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/nanoc/nanoc.git
+  revision: a5c553f8044b5040babcf4cec1e4014d572ddc5f
+  specs:
+    nanoc (4.0.0b4)
+      cri (~> 2.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -9,15 +16,15 @@ GEM
     coderay (1.1.0)
     colored (1.2)
     commonjs (0.2.7)
-    cri (2.6.1)
+    cri (2.7.0)
       colored (~> 1.2)
-    daemons (1.2.1)
+    daemons (1.2.2)
     eventmachine (1.0.7)
-    execjs (2.4.0)
-    ffi (1.9.6)
+    execjs (2.5.2)
+    ffi (1.9.8)
     formatador (0.2.5)
     fssm (0.2.10)
-    guard (2.12.4)
+    guard (2.12.6)
       formatador (>= 0.2.4)
       listen (~> 2.7)
       lumberjack (~> 1.0)
@@ -26,54 +33,52 @@ GEM
       pry (>= 0.9.12)
       shellany (~> 0.0)
       thor (>= 0.18.1)
-    guard-nanoc (1.0.3)
-      guard (~> 2.8)
-      nanoc (~> 3.6)
+    guard-nanoc (1.0.2)
+      guard (>= 1.8.0)
+      nanoc (>= 3.6.3)
     hitimes (1.2.2)
-    json (1.8.2)
+    json (1.8.3)
     less (2.6.0)
       commonjs (~> 0.2.7)
     libv8 (3.16.14.7)
-    listen (2.9.0)
-      celluloid (>= 0.15.2)
+    listen (2.10.1)
+      celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
-    nanoc (3.7.5)
-      cri (~> 2.3)
     nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    posix-spawn (0.3.10)
+    posix-spawn (0.3.11)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pygments.rb (0.6.2)
+    pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
-    rack (1.6.0)
+    rack (1.6.4)
     rainpress (1.0)
-    rb-fsevent (0.9.4)
+    rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rdiscount (2.1.8)
-    redcarpet (3.2.2)
+    redcarpet (3.3.1)
     ref (1.0.5)
     shellany (0.0.1)
-    slim (3.0.3)
+    slim (3.0.6)
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
-    systemu (2.6.4)
-    temple (0.7.5)
-    therubyracer (0.12.1)
+    systemu (2.6.5)
+    temple (0.7.6)
+    therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
     thin (1.6.3)
@@ -100,7 +105,7 @@ DEPENDENCIES
   guard-nanoc
   less
   mime-types
-  nanoc
+  nanoc!
   nokogiri
   pygments.rb
   rainpress
@@ -112,3 +117,6 @@ DEPENDENCIES
   thin
   uglifier
   yuicompressor
+
+BUNDLED WITH
+   1.10.4

--- a/Rules
+++ b/Rules
@@ -12,11 +12,11 @@ preprocess do
   end
 
   tags.each do |tag|
-    items << Nanoc::Item.new("", { tag: tag }, "/nulog/#{tag}/")
+    items.create("", { tag: tag }, "/nulog/#{tag}/")
   end
 
   authors.each do |author|
-    items << Nanoc::Item.new("", { author: author }, "/nulog/#{author}/")
+    items.create("", { author: author }, "/nulog/#{author}/")
   end
 end
 
@@ -113,7 +113,7 @@ route '/css/*/' do
 end
 
 route '/blog/*/' do
-  item.identifier.gsub(%r{^/blog/(\d+)-(\d+)_(.*)$}) do |match|
+  item.identifier.to_s.gsub(%r{^/blog/(\d+)-(\d+)_(.*)$}) do |match|
     "/#{$1}/#{$2}/#{$3}" + 'index.html'
   end
 end

--- a/Rules
+++ b/Rules
@@ -20,65 +20,66 @@ preprocess do
   end
 end
 
-passthrough '/assets/fonts/*'
+passthrough '/assets/fonts/**/*'
+ignore '/assets/stylesheets/_lib/**/*'
 
-compile '/assets/stylesheets/(styles|ie)/' do
+compile '/assets/stylesheets/{styles,ie}/' do
   filter :less
   filter :rainpress
 end
 
-compile '/assets/fonts/*/' do
+compile '/assets/fonts/**/*' do
 end
 
-compile '/assets/javascripts/*/' do
+compile '/assets/javascripts/**/*' do
   filter :uglify_js
 end
 
-compile '/assets/images/*/' do
+compile '/assets/images/**/*' do
 end
 
-compile '/nulog/(business|programming|innovation|society|technology|web|meetup)/' do
-  layout 'blog'
-  layout 'default'
+compile '/nulog/{business,programming,innovation,society,technology,web,meetup}/' do
+  layout '/blog/'
+  layout '/default/'
 end
 
-compile '/nulog/(zaiste|albanlv|julien|adrien|tukan|tomkuk|kasia|adam)/' do
-  layout 'author'
-  layout 'default'
+compile '/nulog/{zaiste,albanlv,julien,adrien,tukan,tomkuk,kasia,adam}/' do
+  layout '/author/'
+  layout '/default/'
 end
 
 compile '/nulog/' do
   filter :slim
-  layout 'default'
+  layout '/default/'
 end
 
-compile '/blog/*/' do
+compile '/blog/**/*' do
   filter :rdiscount, :extensions => %w( strict smart )
-  layout 'post'
-  layout 'default'
+  layout '/post/'
+  layout '/default/'
 end
 
-compile '/projects/*/' do
+compile '/projects/**/*/' do
   filter :rdiscount, :extensions => %w( strict smart )
-  layout 'project'
-  layout 'default'
+  layout '/project/'
+  layout '/default/'
 end
 
-compile 'blast' do
+compile '/blast/' do
   filter :slim
-  layout 'default'
+  layout '/default/'
 end
 
 compile '/contact/' do
   filter :slim
-  layout 'default'
+  layout '/default/'
 end
 
-compile 'sitemap' do
+compile '/sitemap/' do
   filter :slim
 end
 
-compile '*' do
+compile '/**/*' do
   ext = item[:extension].nil? ? nil : item[:extension].split('.').last
 
   if item.binary?
@@ -86,43 +87,43 @@ compile '*' do
   elsif ext == 'md' || ext == 'markdown'
     filter :erb
     filter :rdiscount
-    layout 'blog'
-    layout 'default'
+    layout '/blog/'
+    layout '/default/'
   elsif ext == 'less'
     # do nothing as it should be filtered somewhere before
   else
     filter :slim
-    layout 'default'
+    layout '/default/'
   end
 end
 
-route '/assets/stylesheets/(styles|ie)' do
+route '/assets/stylesheets/{styles,ie}/' do
   item.identifier.chop + '.css'
 end
 
-route '/assets/javascripts/*/' do
+route '/assets/javascripts/**/*' do
   item.identifier.chop + '.js'
 end
 
-route '/assets/images/*/' do
+route '/assets/images/**/*' do
   item.identifier.chop + '.' + item[:extension]
 end
 
-route '/css/*/' do
+route '/css/**/*' do
   item.identifier.chop + '.css'
 end
 
-route '/blog/*/' do
+route '/blog/**/*' do
   item.identifier.to_s.gsub(%r{^/blog/(\d+)-(\d+)_(.*)$}) do |match|
     "/#{$1}/#{$2}/#{$3}" + 'index.html'
   end
 end
 
-route 'sitemap' do
+route '/sitemap/' do
   item.identifier.chop + '.xml'
 end
 
-route '*' do
+route '/**/*' do
   if item.binary?
     # Write item with identifier /foo/ to /foo.ext
     item.identifier.chop + '.' + item[:extension]
@@ -132,4 +133,4 @@ route '*' do
   end
 end
 
-layout '*', :slim
+layout '/**/*', :slim

--- a/Rules
+++ b/Rules
@@ -12,18 +12,25 @@ preprocess do
   end
 
   tags.each do |tag|
-    items.create("", { tag: tag }, "/nulog/#{tag}/")
+    items.create("", { tag: tag }, "/nulog/#{tag}.txt")
   end
 
   authors.each do |author|
-    items.create("", { author: author }, "/nulog/#{author}/")
+    items.create("", { author: author }, "/nulog/#{author}.txt")
   end
 end
 
 passthrough '/assets/fonts/**/*'
 ignore '/assets/stylesheets/_lib/**/*'
 
-compile '/assets/stylesheets/{styles,ie}/' do
+compile '/static/**/*' do
+end
+
+route '/static/**/*' do
+  item.identifier.to_s.sub(/\A\/static/, '')
+end
+
+compile '/assets/stylesheets/{styles,ie}.*' do
   filter :less
   filter :rainpress
 end
@@ -38,44 +45,44 @@ end
 compile '/assets/images/**/*' do
 end
 
-compile '/nulog/{business,programming,innovation,society,technology,web,meetup}/' do
-  layout '/blog/'
-  layout '/default/'
+compile '/nulog/{business,programming,innovation,society,technology,web,meetup}.*' do
+  layout '/blog.*'
+  layout '/default.*'
 end
 
-compile '/nulog/{zaiste,albanlv,julien,adrien,tukan,tomkuk,kasia,adam}/' do
-  layout '/author/'
-  layout '/default/'
+compile '/nulog/{zaiste,albanlv,julien,adrien,tukan,tomkuk,kasia,adam}.*' do
+  layout '/author.*'
+  layout '/default.*'
 end
 
-compile '/nulog/' do
+compile '/nulog.*' do
   filter :slim
-  layout '/default/'
+  layout '/default.*'
 end
 
 compile '/blog/**/*' do
   filter :rdiscount, :extensions => %w( strict smart )
-  layout '/post/'
-  layout '/default/'
+  layout '/post.*'
+  layout '/default.*'
 end
 
-compile '/projects/**/*/' do
+compile '/projects/**/*' do
   filter :rdiscount, :extensions => %w( strict smart )
-  layout '/project/'
-  layout '/default/'
+  layout '/project.*'
+  layout '/default.*'
 end
 
-compile '/blast/' do
+compile '/blast.*' do
   filter :slim
-  layout '/default/'
+  layout '/default.*'
 end
 
-compile '/contact/' do
+compile '/contact.*' do
   filter :slim
-  layout '/default/'
+  layout '/default.*'
 end
 
-compile '/sitemap/' do
+compile '/sitemap.*' do
   # FIXME: slim escapes all output
   filter :slim
 end
@@ -88,49 +95,54 @@ compile '/**/*' do
   elsif ext == 'md' || ext == 'markdown'
     filter :erb
     filter :rdiscount
-    layout '/blog/'
-    layout '/default/'
+    layout '/blog.*'
+    layout '/default.*'
   elsif ext == 'less'
     # do nothing as it should be filtered somewhere before
   else
     filter :slim
-    layout '/default/'
+    layout '/default.*'
   end
 end
 
-route '/assets/stylesheets/{styles,ie}/' do
-  item.identifier.chop + '.css'
+route '/assets/stylesheets/{styles,ie}.*' do
+  item.identifier.with_ext('css')
 end
 
 route '/assets/javascripts/**/*' do
-  item.identifier.chop + '.js'
+  item.identifier.with_ext('.js')
 end
 
 route '/assets/images/**/*' do
-  item.identifier.chop + '.' + item[:extension]
+  item.identifier.to_s
 end
 
+# FIXME: Not used
 route '/css/**/*' do
-  item.identifier.chop + '.css'
+  item.identifier.with_ext('css')
 end
 
 route '/blog/**/*' do
-  item.identifier.to_s.gsub(%r{^/blog/(\d+)-(\d+)_(.*)$}) do |match|
-    "/#{$1}/#{$2}/#{$3}" + 'index.html'
+  item.identifier.to_s.gsub(%r{^/blog/(\d+)-(\d+)_(.*)\..*$}) do |match|
+    "/#{$1}/#{$2}/#{$3}" + '/index.html'
   end
 end
 
-route '/sitemap/' do
-  item.identifier.chop + '.xml'
+route '/sitemap.*' do
+  item.identifier.with_ext('xml')
+end
+
+route '/index.*' do
+  '/index.html'
 end
 
 route '/**/*' do
   if item.binary?
-    # Write item with identifier /foo/ to /foo.ext
-    item.identifier.chop + '.' + item[:extension]
+    # Write item with identifier /foo.dat to /foo.dat
+    item.identifier.to_s
   else
-    # Write item with identifier /foo/ to /foo/index.html
-    item.identifier + 'index.html'
+    # Write item with identifier /foo.md to /foo/index.html
+    item.identifier.without_ext + '/index.html'
   end
 end
 

--- a/Rules
+++ b/Rules
@@ -76,6 +76,7 @@ compile '/contact/' do
 end
 
 compile '/sitemap/' do
+  # FIXME: slim escapes all output
   filter :slim
 end
 

--- a/Rules
+++ b/Rules
@@ -117,11 +117,6 @@ route '/assets/images/**/*' do
   item.identifier.to_s
 end
 
-# FIXME: Not used
-route '/css/**/*' do
-  item.identifier.with_ext('css')
-end
-
 route '/blog/**/*' do
   item.identifier.to_s.gsub(%r{^/blog/(\d+)-(\d+)_(.*)\..*$}) do |match|
     "/#{$1}/#{$2}/#{$3}" + '/index.html'

--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,7 @@ data_sources:
   -
     # The type is the identifier of the data source. By default, this will be
     # `filesystem_unified`.
-    type: filesystem_unified
+    type: filesystem
 
     # The path where items should be mounted (comparable to mount points in
     # Unix-like systems). This is “/” by default, meaning that items will have
@@ -61,9 +61,12 @@ data_sources:
     allow_periods_in_identifiers: true
     encoding: utf-8
     identifier_type: full
-  #-
-    #type: static
-    #identifier_type: full
+  -
+    type: filesystem
+    items_root: /static
+    content_dir: static
+    layouts_dir: null
+    identifier_type: full
 
 # Configuration for the “watch” command, which watches a site for changes and
 # recompiles if necessary.

--- a/config.yaml
+++ b/config.yaml
@@ -60,10 +60,10 @@ data_sources:
     # it will become “/about.html/” instead.
     allow_periods_in_identifiers: true
     encoding: utf-8
-    identifier_type: legacy
+    identifier_type: full
   #-
     #type: static
-    #identifier_type: legacy
+    #identifier_type: full
 
 # Configuration for the “watch” command, which watches a site for changes and
 # recompiles if necessary.

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-string_pattern_type: legacy
+string_pattern_type: glob
 
 # A list of file extensions that nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,5 @@
+string_pattern_type: legacy
+
 # A list of file extensions that nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file
 # will be considered as binary.
@@ -17,7 +19,7 @@ index_filenames: [ 'index.html' ]
 # Whether or not to generate a diff of the compiled content when compiling a
 # site. The diff will contain the differences between the compiled content
 # before and after the last site compilation.
-enable_output_diff: false
+enable_output_diff: true
 
 prune:
   # Whether to automatically remove files not managed by nanoc from the output
@@ -58,8 +60,10 @@ data_sources:
     # it will become “/about.html/” instead.
     allow_periods_in_identifiers: true
     encoding: utf-8
-  -
-    type: static
+    identifier_type: legacy
+  #-
+    #type: static
+    #identifier_type: legacy
 
 # Configuration for the “watch” command, which watches a site for changes and
 # recompiles if necessary.

--- a/content/nulog.slim
+++ b/content/nulog.slim
@@ -2,7 +2,7 @@
 
 section.container.blog
   .article-list
-    - @site.sorted_articles.each do |post|
+    - sorted_articles.each do |post|
       - if post[:publish]
         article.article-item
           h1.article-item-title

--- a/content/nulog.slim
+++ b/content/nulog.slim
@@ -1,4 +1,4 @@
-== render 'blog_header'
+== render '/blog_header.*'
 
 section.container.blog
   .article-list

--- a/content/sitemap.xml
+++ b/content/sitemap.xml
@@ -1,1 +1,1 @@
-= xml_sitemap
+= xml_sitemap items: @items.reject { |i| i.binary? }

--- a/content/sitemap.xml
+++ b/content/sitemap.xml
@@ -1,1 +1,1 @@
-= xml_sitemap items: @items.reject { |i| i.binary? }
+== xml_sitemap items: @items.reject { |i| i.binary? }

--- a/layouts/author.slim
+++ b/layouts/author.slim
@@ -15,4 +15,4 @@ section#main
           li
             a href="#" = post[:created_at].strftime("%b %d")
 
-== render 'sidebar'
+== render '/sidebar.*'

--- a/layouts/blog.slim
+++ b/layouts/blog.slim
@@ -1,4 +1,4 @@
-== render 'blog_header'
+== render '/blog_header.*'
 
 section.container.blog
   .article-list

--- a/layouts/default.slim
+++ b/layouts/default.slim
@@ -34,10 +34,10 @@ html lang="en"
       | <script src="/assets/javascripts/ie/respond.js"></script>
   body
     .wrap
-      == render 'nav'
+      == render '/nav.*'
       == yield
-      == render 'footer'
+      == render '/footer.*'
 
     script src="/assets/javascripts/async.js"
 
-    == render '_ganalytics'
+    == render '/_ganalytics.*'

--- a/layouts/tag.slim
+++ b/layouts/tag.slim
@@ -9,4 +9,4 @@ section#main
           li
             a href="#" = post[:created_at].strftime("%b %d")
 
-== render 'sidebar'
+== render '/sidebar.*'

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -1,11 +1,11 @@
 # All files in the 'lib' directory will be loaded
 # before nanoc starts compiling.
 
-include Nanoc3::Helpers::Blogging
-include Nanoc3::Helpers::LinkTo
-include Nanoc3::Helpers::Rendering
-include Nanoc3::Helpers::XMLSitemap
-include Nanoc3::Helpers::Tagging
+include Nanoc::Helpers::Blogging
+include Nanoc::Helpers::LinkTo
+include Nanoc::Helpers::Rendering
+include Nanoc::Helpers::XMLSitemap
+include Nanoc::Helpers::Tagging
 
 def link_to_with_current(text, path, desc)
   if @item_rep and @item_rep.path == path


### PR DESCRIPTION
nanoc 4 is an upcoming major revision of nanoc. This PR upgrades the Nukomeet site to the current nanoc 4 pre-release.

**Marked WIP because nanoc 4 is not released yet.**
- [x] Do basic upgrade
- [x] Switch to glob patterns
- [x] Switch to identifiers with extensions
- [ ] Wait for final nanoc 4 release
- [ ] Use nanoc 4 from RubyGems

Also see the [nanoc 4 upgrade guide](http://v4.nanoc.ws/doc/nanoc-4-upgrade-guide/).

Some notes on the upgrade:
- The `/assets/stylesheets/_lib` files are no longer written. I’m assuming they are meant for internal use only.
- The `/css/*` rule was removed, as there are no files that match this pattern.
- I fixed escaping issues in the XML sitemap, and also prevented binary items from being included in the sitemap. (These changes could easily be backported to master if necessary.)
